### PR TITLE
Make `ivar consensus` emit shorter FASTA header

### DIFF
--- a/modules/local/ivar.nf
+++ b/modules/local/ivar.nf
@@ -31,6 +31,7 @@ process IVAR_CONSENSUS {
         ivar consensus -p !{task.process}/!{sample}.consensus \
             -t 0.6 \
             -m !{params.mincov} \
+            -i !{sample} \
             2>> $err_file >> $log_file
     '''
 }


### PR DESCRIPTION
Addresses my comment in #3.
