### PR TITLE
Remove `.gz` from BAM outputs

### DIFF
--- a/modules/local/samtools.nf
+++ b/modules/local/samtools.nf
@@ -1,7 +1,7 @@
 process SAMTOOLS_SORT_INDEX {
     publishDir "${params.outdir}", mode: 'copy', pattern: "logs/${task.process}/*.{log,err}"
-    publishDir "${params.outdir}", mode: 'copy', pattern: "${task.process}/*_trimclip.sorted.bam.gz"
-    publishDir "${params.outdir}", mode: 'copy', pattern: "${task.process}/*_trimclip.sorted.bam.gz.bai"
+    publishDir "${params.outdir}", mode: 'copy', pattern: "${task.process}/*_trimclip.sorted.bam"
+    publishDir "${params.outdir}", mode: 'copy', pattern: "${task.process}/*_trimclip.sorted.bam.bai"
     tag "${sample}"
     echo false
     cpus params.medcpus
@@ -11,8 +11,8 @@ process SAMTOOLS_SORT_INDEX {
         tuple val(sample), file(samfile)
 
     output:
-        tuple val(sample), path("${task.process}/${sample}_trimclip.sorted.bam.gz"), emit: bamfile
-        path("${task.process}/${sample}_trimclip.sorted.bam.gz.bai"), emit: bamfile_index
+        tuple val(sample), path("${task.process}/${sample}_trimclip.sorted.bam"), emit: bamfile
+        path("${task.process}/${sample}_trimclip.sorted.bam.bai"), emit: bamfile_index
         path("logs/${task.process}/${sample}.${workflow.sessionId}.{log,err}")
 
     shell:
@@ -27,12 +27,12 @@ process SAMTOOLS_SORT_INDEX {
 
         samtools view -bShu !{samfile} | \
             samtools sort \
-                -o !{task.process}/!{sample}_trimclip.sorted.bam.gz \
+                -o !{task.process}/!{sample}_trimclip.sorted.bam \
                 -@ !{task.cpus} \
                 2>> $err_file >> $log_file
         samtools index \
-            !{task.process}/!{sample}_trimclip.sorted.bam.gz \
-            !{task.process}/!{sample}_trimclip.sorted.bam.gz.bai \
+            !{task.process}/!{sample}_trimclip.sorted.bam \
+            !{task.process}/!{sample}_trimclip.sorted.bam.bai \
             2>> $err_file >> $log_file
     '''
 }


### PR DESCRIPTION
This will make GenBank submission easier. Fixes #16, with no noticeable change in file sizes.

Before:
```none
$ ls -lh results/SAMTOOLS_SORT_INDEX
total 4.1M
-rw-r--r-- 1 fanninpm fanninpm 157K Mar  1 17:19 MA_MGH_00475_trimclip.sorted.bam.gz
-rw-r--r-- 1 fanninpm fanninpm  152 Mar  1 17:19 MA_MGH_00475_trimclip.sorted.bam.gz.bai
-rw-r--r-- 1 fanninpm fanninpm 3.9M Mar  1 17:18 MA_MGH_00476_trimclip.sorted.bam.gz
-rw-r--r-- 1 fanninpm fanninpm  264 Mar  1 17:18 MA_MGH_00476_trimclip.sorted.bam.gz.bai
```

After:
```none
$ ls -lh results/SAMTOOLS_SORT_INDEX
total 4.1M
-rw-r--r-- 1 fanninpm fanninpm 157K Mar  1 18:11 MA_MGH_00475_trimclip.sorted.bam
-rw-r--r-- 1 fanninpm fanninpm  152 Mar  1 18:11 MA_MGH_00475_trimclip.sorted.bam.bai
-rw-r--r-- 1 fanninpm fanninpm 3.9M Mar  1 18:11 MA_MGH_00476_trimclip.sorted.bam
-rw-r--r-- 1 fanninpm fanninpm  264 Mar  1 18:11 MA_MGH_00476_trimclip.sorted.bam.bai
```
