### PR TITLE
Upgrade to Pangolin v4.0

### DIFF
--- a/modules/local/pangolin.nf
+++ b/modules/local/pangolin.nf
@@ -21,19 +21,12 @@ process PANGOLIN {
 
         # time stamp + capturing tool versions
         date | tee -a $log_file $err_file > /dev/null
-        pangolin --version >> $log_file
-        pangolin --pangoLEARN-version >> $log_file
-        pangolin --pango-designation-version >> $log_file
+        pangolin --all-versions >> $log_file
 
         pangolin !{params.pangolin_options} \
             --outdir !{task.process}/ \
             --threads !{task.cpus} \
             !{fasta} \
             2>> $err_file >> $log_file
-
-        # FIXME: Pangolin v4.0 will sort by the first column
-        # Stopgap fix adapted from https://www.gnu.org/software/coreutils/manual/html_node/Header-lines.html
-        mv !{task.process}/lineage_report.csv lineage_report.csv
-        ( sed -u 1q; sort -k 1,1n -t',' ) < lineage_report.csv > !{task.process}/lineage_report.csv
     '''
 }


### PR DESCRIPTION
This fixes #24. (This also removes that stopgap fix, as pangolin's preprocessing will sort all of its given input sequences.)
